### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,9 +13,8 @@ dependencies:
   sass_builder: ^1.0.1
 dev_dependencies:
   browser: ^0.10.0
-web:
-  compiler:
-    debug: dartdevc
+
 transformers:
-  - angular
-  - sass_builder
+- sass_builder:
+      outputExtension: .scss.css
+- angular  


### PR DESCRIPTION
1: Removed compiler flag: dartdevc (specifying compiler is up to end user)
2: Moved sass_builder transformer to occur before angular transformer (angular uses the css files generated by sass_builder)